### PR TITLE
Update Main.java

### DIFF
--- a/src/main/java/net/gonzq/bounties/Main.java
+++ b/src/main/java/net/gonzq/bounties/Main.java
@@ -15,7 +15,6 @@ import java.util.List;
 public final class Main extends JavaPlugin {
 
     public static Main plugin;
-
     private int version;
 
     public BountyFile bounty;
@@ -41,31 +40,22 @@ public final class Main extends JavaPlugin {
         String versionString = Bukkit.getVersion();
         version = 0;
 
-        for (int i = 8; i <= 19; i++) {
-            if (versionString.contains("1." + i)) {
-                version = i;
-            }
+
+        getLogger().info(Bukkit.getBukkitVersion() + " Server detected!");
+        UpdateChecker c = new UpdateChecker(this);
+        int currentVer = Integer.parseInt(getDescription().getVersion().replace(".",""));
+        int newVer = Integer.parseInt(c.getVersion().replace(".",""));
+        List<String> msg = new ArrayList<>();
+        msg.add("=============== Bounties ===============");
+        msg.add("- Plugin made by: Gonzq#4451");
+        msg.add("- Current Version: " + getDescription().getVersion());
+        if (currentVer < newVer) {
+            msg.add("- There is a new version available: " + c.getVersion());
+            msg.add("- Download Link: https://www.spigotmc.org/resources/bounties-1-8-1-19.106551/");
         }
-        if (version == 0) {
-            getLogger().warning("The plugin isn't compatible with this server version! (" + versionString + ")");
-            getLogger().warning("The Plugin has been disabled!");
-            Bukkit.getPluginManager().disablePlugin(this);
-        } else {
-            getLogger().info("1." + version + " Server detected!");
-            UpdateChecker c = new UpdateChecker(this);
-            int currentVer = Integer.parseInt(getDescription().getVersion().replace(".",""));
-            int newVer = Integer.parseInt(c.getVersion().replace(".",""));
-            List<String> msg = new ArrayList<>();
-            msg.add("=============== Bounties ===============");
-            msg.add("- Plugin made by: Gonzq#4451");
-            msg.add("- Current Version: " + getDescription().getVersion());
-            if (currentVer < newVer) {
-                msg.add("- There is a new version available: " + c.getVersion());
-                msg.add("- Download Link: https://www.spigotmc.org/resources/bounties-1-8-1-19.106551/");
-            }
-            msg.add("=============== Bounties ===============");
-            msg.forEach(s -> getLogger().info(s));
-        }
+        msg.add("=============== Bounties ===============");
+        msg.forEach(s -> getLogger().info(s));
+
     }
 
     public int getVersion() {


### PR DESCRIPTION
Basically removed that 'version' loop thing.

If you try to use the plugin in version 1.7 then it will **automatically** disable it.
![image](https://user-images.githubusercontent.com/65754609/205426119-a80eb460-92f3-4678-a55b-550a0348b9b3.png)
The code serves generally no purpose tbh.

Also you might as well use ``Bukkit.getBukkitVersion()`` since it's literally built in with Bukkit's api. 